### PR TITLE
[RET-4528] Clean up some errors in API docs

### DIFF
--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -17,5 +17,3 @@ Error Code | Meaning
 429 | Too Many Requests -- Returned by certain rate-limited endpoints. Slow down. Highly concurrent requests are frowned upon.
 500 | Internal Server Error -- We had a problem with our server. Try again later.
 503 | Service Unavailable -- We're temporarily offline for maintenance. Please try again later.
-
-JSON error responses have the shape `{ "error": "..." }`.

--- a/source/includes/_errors.md
+++ b/source/includes/_errors.md
@@ -8,12 +8,14 @@ Error Code | Meaning
 ---------- | -------
 400 | Bad Request -- Your request was unintelligible. Check your formatting.
 401 | Unauthorized -- Your API key is wrong or missing.
-403 | Forbidden -- You didn't pass in your Company ID or you're using the wrong API key. 
+403 | Forbidden -- You didn't pass in your Company ID or you're using the wrong API key.
 404 | Not Found -- It actually, really doesn't exist.
 405 | Method Not Allowed -- It doesn't respond to the HTTP action you used.
 406 | Not Acceptable -- You requested a format that isn't JSON, or, sigh, XML.
 410 | Gone -- It up and left or was otherwise deleted.
 418 | I'm a little teapot!
-429 | Too Many Requests -- Slow down. Highly concurrent requests are frowned upon.
+429 | Too Many Requests -- Returned by certain rate-limited endpoints. Slow down. Highly concurrent requests are frowned upon.
 500 | Internal Server Error -- We had a problem with our server. Try again later.
 503 | Service Unavailable -- We're temporarily offline for maintenance. Please try again later.
+
+JSON error responses have the shape `{ "error": "..." }`.

--- a/source/includes/_reports.md
+++ b/source/includes/_reports.md
@@ -9,14 +9,14 @@ Parameter | Mandatory | Description
 api_key | Yes | The api_key used to authenticate this request.
 company_id | No | Return reports associated to the specific company IF you have access to that company. If left blank it will default to the current company associated with the user using the api_key.
 domain | Yes | The domain of the report. Currently only 'calls'
-facet | Yes | One of: ['publisher', 'buyer', 'campaign', 'number', 'daily', 'tag_value', 'state']. This is the object that you will want to generate a report for.
+facet | Yes | One of: ['number', 'campaign', 'affiliate', 'target', 'date', 'tag_value', 'state']. This is the object that you will want to generate a report for. For companies with affiliate marketing enabled, `publisher` and `buyer` may be used as aliases for `affiliate` and `target`.
 created_at_start | Yes |
 created_at_end | Yes |
 page | No
 per_page | No
 tag_value_key | No | When faceting by tag_value you may want to provide a second facet to drill down on. [Example](#tag-value-name-report)
 
-NOTE: created_at_start must be before created_at_end and the two must be smaller that 2 years apart.
+NOTE: created_at_start must be before created_at_end and the two must be less than 2 years apart.
 
 ## Buyer Calls In Progress Report
 ~~~shell

--- a/source/includes/_rtb.md
+++ b/source/includes/_rtb.md
@@ -17,7 +17,7 @@ To learn more about the scenarios you can implement with the RTB API, see the gu
 > Passing data as URL Params
 
 ~~~shell
-curl -X POST "https://rtb.retreaver.com/rtbs.json?" \
+curl -X POST "https://rtb.retreaver.com/rtbs.json" \
   -d "key=7fc40342-f0a0-4e8f-bf09-b3887eedcb41" \
   -d "publisher_id=retreaver_pub" \
   -d "caller_number=+18558485518"
@@ -27,6 +27,7 @@ curl -X POST "https://rtb.retreaver.com/rtbs.json?" \
 
 ~~~shell
 curl -X POST "https://rtb.retreaver.com/rtbs.json" \
+  -H "Content-Type: application/json" \
   -d '{
 	"key": "7fc40342-f0a0-4e8f-bf09-b3887eedcb41",
 	"publisher_id": "retreaver_pub",
@@ -45,7 +46,7 @@ Parameter | Mandatory | Description
 --------- | ------- | -----------
 key | Yes | Postback key, found on the campaign page where the Real Time Bidding Postback Key is issued.
 publisher_id/source_id | Yes | The Source/Affiliate/Publisher this bid is going to be attributed to.
-caller_number | Yes | The caller number.
+caller_number | Conditional | The caller number, unless the postback key allows requests without one.
 inbound_number | No | If provided the `rtb` will expect the caller to call this number. If not provided the `rtb` will return a temporary number.
 tags | No | Providing additional query parameters will result in tagging the `rtb` with those additional values. Please view the examples below.
 
@@ -58,6 +59,7 @@ Additional information could be passed along as params to the request. In this c
 
 ~~~shell
 curl -X POST "https://rtb.retreaver.com/rtbs.json" \
+  -H "Content-Type: application/json" \
   -d '{
 	"key": "7fc40342-f0a0-4e8f-bf09-b3887eedcb41",
 	"publisher_id": "retreaver_pub",
@@ -99,6 +101,7 @@ age | 25
 
 ~~~shell
 curl -X POST "https://rtb.retreaver.com/rtbs.json" \
+	-H "Content-Type: application/json" \
  	-d '{
 		"key": "7fc40342-f0a0-4e8f-bf09-b3887eedcb41",
 		"publisher_id": "retreaver_pub",
@@ -142,6 +145,7 @@ inbound_number | +12029795452
 
 ~~~shell
 curl -X PUT "https://rtb.retreaver.com/rtbs/c6e4ce37-9b49-46af-bd8e-16cb7753499d.json" \
+  -H "Content-Type: application/json" \
   -d '{
 	"key": "7fc40342-f0a0-4e8f-bf09-b3887eedcb41",
 	"status": "confirmed"
@@ -177,7 +181,7 @@ When a reservation is created in Retreaver, it is not immediately counted agains
 
 To apply a reservation to the caps, it must first be confirmed.
 
-To confirm the resevration send a PUT/PATCH request
+To confirm the reservation send a PUT/PATCH request
 
 
 #### Parameters
@@ -191,7 +195,7 @@ status | "confirmed" | 'confirmed' will confirm the reservation
 <aside class="notice">
 Reservations can be automatically applied to caps if this behavior is enabled on the postback key.
 
-Otherwise, they must be explicitly confirm by sending a PUT/PATCH request to the reservation URL with a status="confirmed" param.
+Otherwise, they must be explicitly confirmed by sending a PUT/PATCH request to the reservation URL with a status="confirmed" param.
 </aside>
 
 <aside class="notice">
@@ -209,6 +213,7 @@ When a reservation is confirmed, the publisher is <strong>expected to place the 
 
 ~~~shell
 curl -X POST "https://rtb.retreaver.com/rtbs.json" \
+ -H "Content-Type: application/json" \
  -d '{
  	"key": 7fc40342-f0a0-4e8f-bf09-b3887eedcb41"
  	"publisher_id": "retreaver_pub",
@@ -216,6 +221,7 @@ curl -X POST "https://rtb.retreaver.com/rtbs.json" \
  }'
 
 curl -X POST "https://rtb.retreaver.com/rtbs.json" \
+ -H "Content-Type: application/json" \
  -d '{
  	"key": 7fc40342-f0a0-4e8f-bf09-b3887eedcb41"
  	"publisher_id": "retreaver_pub",

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3668,7 +3668,7 @@ The preferred approach is to use the Caller List Number endpoint (GET <a href='#
 curl -X POST 'https://api.retreaver.com/api/v2/targets/:target_id/caller_lists/:name/caller_list_checks.json?key=:postback_key_uuid' \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer :postback_key_secret_key" \
-    -d '{"number": "+15855752500"}'
+    -d '{"caller_list_check": {"number": "+15855752500"}}'
 ~~~
 
 > The above command returns JSON structured like this:

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -28,11 +28,11 @@ our [Retreaver.js](https://github.com/retreaver/retreaver-js) library.
 
 The API can be used to automate core business processes, but does not currently support all functionality.
 
-*Please note: We're currently working on a better, versioned replacement for this API. But don't worry, this API isn't going away.*
+The API is available at versioned paths (such as `/api/v1` and `/api/v2`) and at legacy versionless paths. Use the version shown in each endpoint below; versionless routes remain supported for resources that expose them.
 
 ## Version
 
-This is our *unversioned* API and for sake of clarity we'll refer to it henceforth as:
+For sake of clarity we'll refer to this collection of endpoints as:
 
 `Retreaver Core API`
 
@@ -260,7 +260,7 @@ Final Result: 939 calls processed in 8.84 seconds.
 
 ~~~shell
 # With cURL, you can just pass the correct API key and company_id with each request.
-curl "https://api.retreaver.com/call.json?api_key=woofwoofwoof&company_id=1"
+curl "https://api.retreaver.com/calls.json?api_key=woofwoofwoof&company_id=1"
 ~~~
 
 > Make sure to replace `woofwoofwoof` with your API key.
@@ -1061,17 +1061,17 @@ When using GET place the params in the URL
 > GET
 
 ~~~bash
-curl "https://reteaverdata.com/data_writing/:postback_key_uuid?caller_number=:caller_number&age=39&utm_campaign=auto"
+curl "https://retreaverdata.com/data_writing?key=:postback_key_uuid&caller_number=:caller_number&age=39&utm_campaign=auto"
 ~~~
 
 > POST
 
 ~~~bash
-curl -X POST "https://reteaverdata.com/data_writing" \
+curl -X POST "https://retreaverdata.com/data_writing" \
   -H "Content-Type: application/json" \
   -d '{
-    "key": postback_key_uuid,
-    "caller_number": :caller_number,
+    "key": "postback_key_uuid",
+    "caller_number": ":caller_number",
     "age": "39",
     "utm_campaign": "auto"
   }'
@@ -1112,7 +1112,7 @@ curl -X POST "https://reteaverdata.com/data_writing" \
 | Parameter      | Type       | Required | Description                                  |
 |----------------|------------|----------|----------------------------------------------|
 | key            | string     | Yes      | The UUID of the Postback Key used to authorize this change |
-| caller_number  | string     | Optional | The caller number of the Call for which the tags should be applied. This or a call_uuid should be provider |
+| caller_number  | string     | Optional | The caller number of the Call for which the tags should be applied. This or a call_uuid should be provided. |
 | call_uuid      | string     | Optional | The uuid of the Call for which the tags should be applied. This or a caller_number should be provided. |
 | :tag_key       | string     | Optional | Dynamic key:value pairs in the form of '?key1=value1&key2=value2' |
 
@@ -1157,7 +1157,7 @@ curl "https://api.retreaver.com/api/v1/affiliates.xml?api_key=woofwoofwoof&compa
     <afid>0002</afid>
     <first-name>Nancy</first-name>
     <last-name>Drew</last-name>
-    <company-name>Acme</last-name>
+    <company-name>Acme</company-name>
     <updated-at type="datetime">2012-05-03T15:56:01Z</updated-at>
     <created-at type="datetime">2012-05-03T15:56:01Z</created-at>
   </affiliate>
@@ -1175,7 +1175,7 @@ Provides a complete list of Affiliates.
 ## Get a specific Affiliate by your ID
 
 ~~~shell
-curl "https://api.retreaver.com/api/v1/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1"
+curl "https://api.retreaver.com/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1"
 ~~~
 
 Finds an Affiliate by AFID.
@@ -1183,7 +1183,7 @@ Finds an Affiliate by AFID.
 
 ### HTTP Request
 
-`GET https://api.retreaver.com/api/v1/affiliates/afid/0002.xml?api_key=woofwoofwoof&company_id=1`
+`GET https://api.retreaver.com/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1`
 
 
 ## Create an Affiliate
@@ -1223,7 +1223,7 @@ company_name | string | null |   | Their company name.
 ~~~shell
 curl -s \
     -X PUT \
-    https://api.retreaver.com/api/v1/affiliates/afid/002.json \
+    https://api.retreaver.com/affiliates/afid/002.json \
     -H "Content-Type: application/json" \
     -d '{"affiliate":{"first_name":"Nathan"}}'
 ~~~
@@ -1253,7 +1253,7 @@ You must replace <code>0002</code> with the afid of the Affiliate you want to de
 
 ### HTTP Request
 
-`PUT https://api.retreaver.com/api/v1/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1`
+`PUT https://api.retreaver.com/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1`
 
 `Content-Type: application/json`
 
@@ -1264,7 +1264,7 @@ You must replace <code>0002</code> with the afid of the Affiliate you want to de
 ## Remove an affiliate
 
 ~~~shell
-curl -X DELETE https://api.retreaver.com/api/v1/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1
+curl -X DELETE https://api.retreaver.com/affiliates/afid/0002.json?api_key=woofwoofwoof&company_id=1
 ~~~
 
 Deletes the given Affiliate. You must delete any Numbers the Affiliate has before deleting the Affiliate.
@@ -2086,7 +2086,7 @@ dedupe_seconds | integer | 0 (Disabled) |  | Prevent a repeat caller from causin
 affiliate_can_pull_number | boolean | false | |  Allow affiliates to access this campaign via our LinkTrust integration.
 record_calls | boolean | true | | Toggles call recording on and off.
 message | string |  |  | *Text-to-speech*  A message you want read aloud to the caller when they dial your number. Make sure to tell them to press one to continue.
-voice_gender | string | Male |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
+voice_gender | string | Female |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
 message_file | file |  |  | *Audio File* An audio file you would like played for the caller when they dial your number. Use this field with multipart/form-data submissions.
 message_file_b64_data | string |  |  | *Audio File* A Base64-encoded audio file. Only use this field if you're not using the message_file field.
 message_file_b64_filename | string | |  | *Audio File* The original file name for the Base64-encoded audio file. Something like 'memo.flac'. We suggest using the highest quality audio available.
@@ -2449,7 +2449,7 @@ destroy_nested | boolean | false | | When set, causes existing timers and menu_o
 Parameter | Type | Default | Required | Description
 --------- | ---- | ------- | -------- | -----------
 message | string |  |  | *Text-to-speech*  A message you want read aloud to the caller when they dial your number. Make sure to tell them to press one to continue.
-voice_gender | string | Male |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
+voice_gender | string | Female |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
 message_file | file |  |  | *Audio File* An audio file you would like played for the caller when they dial your number. Use this field with multipart/form-data submissions.
 message_file_b64_data | string |  |  | *Audio File* A Base64-encoded audio file. Only use this field if you're not using the message_file field.
 message_file_b64_filename | string | |  | *Audio File* The original file name for the Base64-encoded audio file. Something like 'memo.flac'. We suggest using the highest quality audio available.
@@ -3493,7 +3493,7 @@ action-specific permission. For example, downloading the numbers on a list requi
 
 Caller lists are created on a specific Target or Campaign.
 
-Numbers could be manages on the caller list after creating them.
+Numbers can be managed on the caller list after creating it.
 
 ### Create caller list
 
@@ -3654,8 +3654,8 @@ key       | uuid | null    | required | the postback_key UUID
 number    | string | null    | required | A phone number in preferably in [E.164 format](https://en.wikipedia.org/wiki/E.164), but NANP format is also accepted
 
 If the caller number is on the list there will be an HTTP 200 response showing the number and the number metadata.
-When the caller number is not on the list there will be an HTTP 404 response and this caller number is not on the caller lists.
-When a status number of 200 is required even when the caller number is not present on the list then
+When the caller number is not on the list, the API returns HTTP 404, indicating that it is not on the caller list.
+When a status code of 200 is required even when the caller number is not present on the list, then
 the endpoint for CallerListChecks could be used
 
 ## Caller List Checks
@@ -3668,16 +3668,14 @@ The preferred approach is to use the Caller List Number endpoint (GET <a href='#
 curl -X POST 'https://api.retreaver.com/api/v2/targets/:target_id/caller_lists/:name/caller_list_checks.json?key=:postback_key_uuid' \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer :postback_key_secret_key" \
-    -d '{"caller_list_check":  { "number": "+15855752500" }}'
+    -d '{"number": "+15855752500"}'
 ~~~
 
 > The above command returns JSON structured like this:
 
 ~~~json
 {
-    "caller_list_check": {
-        "status": "present",
-    }
+    "status": "present"
 }
 ~~~
 
@@ -3704,7 +3702,7 @@ caller_list_check[number]  | required | A phone number in preferably in [E.164 f
 
 | Field | Type | Description | Possible Values |
 |-------|------|--------------|-----------------|
-| `caller_list_check[status]` | string | Indicates the caller number presence status | `present`, `not-present` |
+| `status` | string | Indicates the caller number presence status | `present`, `not-present` |
 
 ## Caller List Uploads
 
@@ -3728,7 +3726,7 @@ curl -X POST 'https://api.retreaver.com/api/v2/targets/:target_id/caller_lists/:
 ~~~json
 {
   "caller_list_upload": {
-    "status": "Processing",
+    "status": "waiting",
     "created_at": "2025-04-30T13:29:40.100+03:00",
     "error_messages": [],
     "clear_before_upload": false,
@@ -3932,7 +3930,7 @@ By sending a `PUT` request you can update properties such as `can_resubscribe` a
 
 ~~~shell
 curl -s \
-    -X POST \
+    -X PUT \
     https://api.retreaver.com/suppressed_numbers/+13216065590.json?api_key=woofwoofwoof&company_id=1 \
     -H "Content-Type: application/json" \
     -d '{"suppressed_number": {"can_resubscribe": false}}'
@@ -3940,11 +3938,13 @@ curl -s \
 
 ### HTTP request
 
-`PUT http://api.retreaver.com/suppressed_numbers/+13216065590.json?api_key=woofwoofwoof&company_id=1`
+`PUT https://api.retreaver.com/suppressed_numbers/+13216065590.json?api_key=woofwoofwoof&company_id=1`
 
 `Content-Type: application/json`
 
-`{"can_resubscribe": false, "campaign_id": "116dc0f6"}`
+`{"suppressed_number": {"can_resubscribe": false, "campaign_id": 116}}`
+
+`campaign_id` is the numeric internal Campaign ID, not the campaign `cid`.
 
 
 # Static Caller Numbers

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -28,11 +28,11 @@ our [Retreaver.js](https://github.com/retreaver/retreaver-js) library.
 
 The API can be used to automate core business processes, but does not currently support all functionality.
 
-The API is available at versioned paths (such as `/api/v1` and `/api/v2`) and at legacy versionless paths. Use the version shown in each endpoint below; versionless routes remain supported for resources that expose them.
+*Please note: We're currently working on a better, versioned replacement for this API. But don't worry, this API isn't going away.*
 
 ## Version
 
-For sake of clarity we'll refer to this collection of endpoints as:
+This is our *unversioned* API and for sake of clarity we'll refer to it henceforth as:
 
 `Retreaver Core API`
 


### PR DESCRIPTION
- Clarify API versioning and correct legacy/versioned endpoint usage.
- Fix malformed authentication, data-writing, affiliate AFID, and suppression URLs.
- Correct caller-list response payloads and upload statuses.
- Update RTB request examples and required headers.
- Correct report facets, aliases, and date-range wording.
- Improve API error and voice-gender documentation.