### PR TITLE
[RET-4586] Document Female as the voice_gender default

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -2307,7 +2307,7 @@ dedupe_seconds | integer | 0 (Disabled) |  | Prevent a repeat caller from causin
 affiliate_can_pull_number | boolean | false | |  Allow affiliates to access this campaign via our LinkTrust integration.
 record_calls | boolean | true | | Toggles call recording on and off.
 message | string |  |  | *Text-to-speech*  A message you want read aloud to the caller when they dial your number. Make sure to tell them to press one to continue.
-voice_gender | string | Male |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
+voice_gender | string | Female |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
 message_file | file |  |  | *Audio File* An audio file you would like played for the caller when they dial your number. Use this field with multipart/form-data submissions.
 message_file_b64_data | string |  |  | *Audio File* A Base64-encoded audio file. Only use this field if you're not using the message_file field.
 message_file_b64_filename | string | |  | *Audio File* The original file name for the Base64-encoded audio file. Something like 'memo.flac'. We suggest using the highest quality audio available.
@@ -2670,7 +2670,7 @@ destroy_nested | boolean | false | | When set, causes existing timers and menu_o
 Parameter | Type | Default | Required | Description
 --------- | ---- | ------- | -------- | -----------
 message | string |  |  | *Text-to-speech*  A message you want read aloud to the caller when they dial your number. Make sure to tell them to press one to continue.
-voice_gender | string | Male |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
+voice_gender | string | Female |  | *Text-to-speech*  Male or Female, the gender of the text-to-speech voice you want.
 message_file | file |  |  | *Audio File* An audio file you would like played for the caller when they dial your number. Use this field with multipart/form-data submissions.
 message_file_b64_data | string |  |  | *Audio File* A Base64-encoded audio file. Only use this field if you're not using the message_file field.
 message_file_b64_filename | string | |  | *Audio File* The original file name for the Base64-encoded audio file. Something like 'memo.flac'. We suggest using the highest quality audio available.


### PR DESCRIPTION
The campaign and number `voice_gender` param tables claimed the default is **Male**. Reality has always been **Female**: the backend renders anything that is not exactly `"Male"` as the female voice, and callpixels#4513 now stores `Female` explicitly when the param is omitted (responses show `"voice_gender": "Female"` instead of `null`).

Two cells changed (campaigns and numbers param tables). The `source/old/*.md` pages describe the param without claiming a default, so they're untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKcuCUr7ouSggFoX58CMM6